### PR TITLE
refactor: remove unused enumerate

### DIFF
--- a/d3graph/d3graph.py
+++ b/d3graph/d3graph.py
@@ -565,7 +565,9 @@ class d3graph:
         if not isinstance(color, str): color = '#808080'
         if color=='cluster': color = '#808080'
         # Set defaults
-        labx = {key: {'name': key, 'color': color, 'group': '-1'} for i, key in enumerate(node_names)}
+        labx = {
+            key: {'name': key, 'color': color, 'group': '-1'} for key in node_names
+        }
 
         df = adjmat2vec(self.adjmat.copy())
         G = nx.from_pandas_edgelist(df, edge_attr=True, create_using=nx.MultiGraph)


### PR DESCRIPTION
This change removes the use of `enumerate` in a dictionary comprehension where the index is unused.

This is a no-op change. The output remains as it was.